### PR TITLE
Add code format for import keyword completion

### DIFF
--- a/core/src/itest/java/idea/plugin/protoeditor/lang/completion/PbCompleteKeywordsTest.java
+++ b/core/src/itest/java/idea/plugin/protoeditor/lang/completion/PbCompleteKeywordsTest.java
@@ -61,7 +61,7 @@ public class PbCompleteKeywordsTest extends PbCompletionContributorTestCase {
   public void testImportAtTopLevel() {
     setInput("imp" + CARET_TAG);
     assertTrue(completeWithUniqueChoice());
-    assertResult("import ");
+    assertResult("import \"\";");
   }
 
   public void testMessageInMessageAutoInsertSpace() {


### PR DESCRIPTION
Fixes #9 
add better format for import keyword.

those change make import like this 
```erlang
import "|";
```
`|` means editor offset