### PR TITLE
Adds Support for erlang

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,6 +28,13 @@ http_archive(
     url = "https://plugins.jetbrains.com/files/9568/91477/intellij-go-201.8538.31.199.zip",
 )
 
+http_archive(
+    name = "erlang_2020_1",
+    build_file = "@//build_support/external:BUILD.idea_erlang",
+    sha256 = "8b1694978ae6f2b7e7801904d29c5c814f33b144d34a47e72b0df6b2476695bd",
+    url = "https://plugins.jetbrains.com/files/7083/83262/intellij-erlang-0.11.1059.zip",
+)
+
 # jflex for IDEA
 jvm_maven_import_external(
     name = "idea_jflex",

--- a/build_support/BUILD
+++ b/build_support/BUILD
@@ -23,6 +23,11 @@ alias(
     actual = "@python_2020_1//:plugin_sdk"
 )
 
+alias(
+    name = "_erlang_support_internal",
+    actual = "@erlang_2020_1//:plugin_sdk"
+)
+
 #
 # Tools
 #
@@ -108,5 +113,17 @@ java_library(
 java_library(
     name = "test_plugin_python_support",
     exports = [":_python_support_internal"],
+    testonly = 1,
+)
+
+java_library(
+    name = "plugin_erlang_support",
+    exports = [":_erlang_support_internal"],
+    neverlink = 1,
+)
+
+java_library(
+    name = "test_plugin_erlang_support",
+    exports = [":_erlang_support_internal"],
     testonly = 1,
 )

--- a/build_support/external/BUILD
+++ b/build_support/external/BUILD
@@ -4,4 +4,5 @@ exports_files([
     "BUILD.idea_go",
     "BUILD.grammar_kit",
     "BUILD.idea_jflex",
+    "BUILD.idea_erlang",
 ])

--- a/build_support/external/BUILD.idea_erlang
+++ b/build_support/external/BUILD.idea_erlang
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+java_import(
+    name = 'plugin_sdk',
+    jars = glob(['intellij-erlang/lib/*.jar']),
+)

--- a/erlang/BUILD
+++ b/erlang/BUILD
@@ -1,0 +1,24 @@
+# Description: IntelliJ protobuf plugin - erlang language support.
+#
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:private"])
+
+alias(
+    name = "erlang",
+    actual = "//erlang/src/main:erlang",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "optional_plugin_xml",
+    actual = "//erlang/src/main:optional_plugin_xml",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "plugin_library",
+    actual = "//erlang/src/main:plugin_library",
+    visibility = ["//:plugin"],
+)

--- a/erlang/src/main/BUILD
+++ b/erlang/src/main/BUILD
@@ -1,0 +1,35 @@
+# Description: IntelliJ protobuf plugin - Python language support sources.
+#
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//erlang:__subpackages__"])
+
+load(
+    "//build_support/build_defs:build_defs.bzl",
+    "intellij_plugin_library",
+    "optional_plugin_xml",
+)
+
+java_library(
+    name = "erlang",
+    srcs = glob(["java/**/*.java"]),
+    deps = [
+        "//build_support:plugin_api",
+        "//build_support:plugin_erlang_support",
+        "//core",
+        "//gencode",
+    ],
+)
+
+optional_plugin_xml(
+    name = "optional_plugin_xml",
+    module = "org.jetbrains.erlang",
+    plugin_xml = "resources/META-INF/erlang_optional.xml",
+)
+
+intellij_plugin_library(
+    name = "plugin_library",
+    optional_plugin_xmls = [":optional_plugin_xml"],
+    deps = [":erlang"],
+)

--- a/erlang/src/main/java/idea/plugin/protoeditor/erlang/ErlFileReferenceContext.java
+++ b/erlang/src/main/java/idea/plugin/protoeditor/erlang/ErlFileReferenceContext.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package idea.plugin.protoeditor.erlang;
+
+import com.google.common.collect.Lists;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.util.QualifiedName;
+
+import org.intellij.erlang.psi.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Determines the erlang file and qualified name that is referenced from a erlang qualified
+ * reference expression.
+ */
+public class ErlFileReferenceContext {
+
+  private final QualifiedName fileLocalSymbol;
+  private final ErlangFile file;
+
+  private ErlFileReferenceContext(ErlangFile file, QualifiedName fileLocalSymbol) {
+    this.file = file;
+    this.fileLocalSymbol = fileLocalSymbol;
+  }
+
+  /**
+   * Determines if the given element is a reference expression where a part of the qualifiers
+   * resolves to a {@link ErlangFile}. If so, returns a pair of the resolved file and the trailing
+   * qualifiers. E.g., given "#pb{filed =1}" returns (pb.hrl, pb.field)
+   *
+   * @param erlangElement erlang element under consideration
+   * @return resolved file + trailing qualifier if found, otherwise null
+   */
+  @Nullable
+  static ErlFileReferenceContext findContext(PsiElement erlangElement) {
+    ErlangRecordField recordField = PsiTreeUtil.getParentOfType(erlangElement, ErlangRecordField.class);
+    List<String> reversedQualifiers = new ArrayList<>();
+    if (recordField != null){
+      ErlangQAtom fieldNameAtom = recordField.getFieldNameAtom();
+      // must be field atom
+      if (!PsiTreeUtil.isAncestor(fieldNameAtom, erlangElement, false)) return null;
+      reversedQualifiers.add(fieldNameAtom.getText());
+      ErlangRecordExpression recordExpression =
+              PsiTreeUtil.getParentOfType(erlangElement, ErlangRecordExpression.class);
+      ErlangRecordRef recordRef = recordExpression != null ? recordExpression.getRecordRef() : null;
+      if (recordRef == null) return null;
+      return getContextByRef(reversedQualifiers, recordRef);
+    }
+    ErlangRecordRef recordRef = PsiTreeUtil.getParentOfType(erlangElement, ErlangRecordRef.class);
+    if (recordRef != null){
+      return getContextByRef(reversedQualifiers, recordRef);
+    }
+
+    return null;
+  }
+
+  @Nullable
+  private static ErlFileReferenceContext getContextByRef(List<String> reversedQualifiers, ErlangRecordRef recordRef) {
+    reversedQualifiers.add(recordRef.getText());
+    PsiElement resolve = recordRef.getReference().resolve();
+    if (resolve == null) return null;
+    PsiFile resolvedFile = resolve.getContainingFile();
+    if (resolvedFile instanceof ErlangFile) {
+      return new ErlFileReferenceContext((ErlangFile) resolvedFile, QualifiedName.fromComponents(Lists.reverse(reversedQualifiers)));
+    }
+    return null;
+  }
+
+  ErlangFile getFile() {
+    return file;
+  }
+
+  QualifiedName getFileLocalSymbol() {
+    return fileLocalSymbol;
+  }
+}

--- a/erlang/src/main/java/idea/plugin/protoeditor/erlang/PbErlangDocumentProvider.java
+++ b/erlang/src/main/java/idea/plugin/protoeditor/erlang/PbErlangDocumentProvider.java
@@ -1,0 +1,65 @@
+package idea.plugin.protoeditor.erlang;
+
+import com.google.common.collect.ImmutableCollection;
+import com.intellij.lang.documentation.AbstractDocumentationProvider;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import idea.plugin.protoeditor.lang.psi.*;
+import idea.plugin.protoeditor.lang.psi.util.PbCommentUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class PbErlangDocumentProvider extends AbstractDocumentationProvider {
+  public PbErlangDocumentProvider() {
+    super();
+  }
+
+  @Nullable
+  @Override
+  public String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
+    ErlFileReferenceContext context = ErlFileReferenceContext.findContext(originalElement);
+    if (context != null && originalElement!=null) {
+      ImmutableCollection<? extends PbElement> matches = PbErlangGotoDeclarationHandler.erlangToProto(context, originalElement.getProject());
+      if (matches == null || matches.isEmpty()) {
+        return null;
+      }
+      PbElement pbElement = matches.iterator().next();
+      return generatePbDoc(pbElement);
+    }
+    return null;
+  }
+
+  public String generatePbDoc(PbElement element) {
+    if (!(element instanceof PbCommentOwner)) {
+      return null;
+    }
+
+    PbCommentOwner owner = (PbCommentOwner) element;
+    List<PsiComment> comments = owner.getComments();
+    if (comments.isEmpty()) {
+      return null;
+    }
+
+    StringBuilder commentBuilder = new StringBuilder("<pre>");
+    for (String line : PbCommentUtil.extractText(comments)) {
+      commentBuilder.append(StringUtil.escapeXmlEntities(line));
+      commentBuilder.append("\n");
+    }
+    appendPbMessage(commentBuilder, element);
+    commentBuilder.append("</pre>");
+    return commentBuilder.toString();
+  }
+
+  private void appendPbMessage(StringBuilder commentBuilder, PbElement pbElement){
+    if (pbElement instanceof PbSimpleField)
+      commentBuilder.append(pbElement.getText()).append("\n");
+    PbMessageDefinition definition = PsiTreeUtil.getParentOfType(pbElement, PbMessageDefinition.class, false, PbFile.class);
+    if (definition != null){
+      commentBuilder.append("\n").append(definition.getText());
+    }
+  }
+
+}

--- a/erlang/src/main/java/idea/plugin/protoeditor/erlang/PbErlangGotoDeclarationHandler.java
+++ b/erlang/src/main/java/idea/plugin/protoeditor/erlang/PbErlangGotoDeclarationHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package idea.plugin.protoeditor.erlang;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.util.QualifiedName;
+import idea.plugin.protoeditor.lang.psi.PbElement;
+import idea.plugin.protoeditor.lang.psi.PbNamedElement;
+import idea.plugin.protoeditor.lang.stub.index.ShortNameIndex;
+import org.intellij.erlang.ErlangLanguage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+/** Handles goto declaration from erlang generated code -> .proto files. */
+public final class PbErlangGotoDeclarationHandler implements GotoDeclarationHandler {
+
+  @Nullable
+  @Override
+  public String getActionText(@NotNull DataContext context) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public PsiElement[] getGotoDeclarationTargets(
+      @Nullable PsiElement sourceElement, int offset, Editor editor) {
+    if (sourceElement == null) {
+      return null;
+    }
+    if (!sourceElement.getLanguage().is(ErlangLanguage.INSTANCE)) {
+      return null;
+    }
+    ErlFileReferenceContext context = ErlFileReferenceContext.findContext(sourceElement);
+    if (context == null) {
+      return null;
+    }
+    Collection<? extends PbElement> matches = erlangToProto(context, sourceElement.getProject());
+    if (matches == null || matches.isEmpty()) {
+      return null;
+    }
+    return matches.toArray(new PsiElement[0]);
+  }
+
+  public static ImmutableCollection<? extends PbElement> erlangToProto(
+          ErlFileReferenceContext referenceContext, Project project) {
+    return findPbByIndex(referenceContext.getFileLocalSymbol(), project);
+  }
+
+  private static ImmutableCollection<? extends PbElement> findPbByIndex(QualifiedName protoName, Project project) {
+    String nameFirst = protoName.getFirstComponent();
+    if (nameFirst == null) return null;
+    Collection<PbNamedElement> pbNamedElements = ShortNameIndex.getInstance().get(nameFirst, project, GlobalSearchScope.projectScope(project));
+    if (pbNamedElements.size() > 0)
+      return ImmutableList.copyOf(pbNamedElements);
+    return null;
+  }
+}

--- a/erlang/src/main/resources/META-INF/erlang_optional.xml
+++ b/erlang/src/main/resources/META-INF/erlang_optional.xml
@@ -1,0 +1,8 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+    <!-- Erlang -> proto goto -->
+    <gotoDeclarationHandler
+      implementation="idea.plugin.protoeditor.erlang.PbErlangGotoDeclarationHandler" order="first"/>
+    <lang.documentationProvider language="Erlang" implementationClass="idea.plugin.protoeditor.erlang.PbErlangDocumentProvider" order="first" />
+  </extensions>
+</idea-plugin>

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -25,6 +25,7 @@ java_library(
         "//java",
         "//python",
         "//golang",
+        "//erlang",
     ]
 )
 
@@ -34,6 +35,7 @@ intellij_plugin_library(
         "//golang:optional_plugin_xml",
         "//java:optional_plugin_xml",
         "//python:optional_plugin_xml",
+        "//erlang:optional_plugin_xml",
     ],
     plugin_xmls = ["//core:plugin_xml"],
     deps = [":combined_lib"],


### PR DESCRIPTION
add erlang support with proto.
use `ShortNameIndex` to find where proto element located.

Support erlang record generate refrence with proto files, support record field goto proto element, also document for record and fields.

i'm not so good at Java and IDEA plugin test, i don't konw how to write test case for this. 
but i could offer test file and what they should do
or is there any document of how to write plugin testcase. i would happy to learn and complete it.