### PR TITLE
Add require-restart to plugin.xml

### DIFF
--- a/build_support/build_defs/build_defs.bzl
+++ b/build_support/build_defs/build_defs.bzl
@@ -56,6 +56,7 @@ def stamped_plugin_xml(
         changelog_file = None,
         description_file = None,
         vendor_file = None,
+        require_restart = False,
         **kwargs):
     """Stamps a plugin xml file with the IJ build number.
 
@@ -126,6 +127,9 @@ def stamped_plugin_xml(
     if vendor_file:
         args.append("--vendor_file=$(location {vendor_file})")
         srcs.append(vendor_file)
+
+    if require_restart:
+        args.append("--require_restart")
 
     cmd = " ".join(args).format(
         plugin_xml = plugin_xml,

--- a/build_support/build_defs/stamp_plugin_xml.py
+++ b/build_support/build_defs/stamp_plugin_xml.py
@@ -78,6 +78,11 @@ parser.add_argument(
     "--vendor_file",
     help="File with vendor element data to add to plugin.xml",
 )
+parser.add_argument(
+    "--require_restart",
+    action="store_true",
+    help="Add require-restart parameter to root node",
+)
 
 
 def _read_changelog(changelog_file):
@@ -152,6 +157,8 @@ def main():
 
     if args.plugin_xml:
         dom = minidom.parse(args.plugin_xml)
+    elif args.require_restart:
+        dom = minidom.parseString("<idea-plugin require-restart=\"true\"/>")
     else:
         dom = minidom.parseString("<idea-plugin/>")
 

--- a/core/src/main/resources/META-INF/plugin.xml
+++ b/core/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,5 @@
 <idea-plugin>
+  <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
 
   <extensionPoints>

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -56,6 +56,7 @@ stamped_plugin_xml(
     stamp_until_build = True,
     vendor_file = "vendor.xml",
     version_file = ":version_file",
+    require_restart = "true",
 )
 
 intellij_plugin(


### PR DESCRIPTION
Force disable handling this as a dynamic plugin. Installing, uninstalling, enabling, disabling all require IDE restart. Workaround for #55.